### PR TITLE
Feature implemented Insurance policy management

### DIFF
--- a/backend/src/main/java/com/chalana/insurance/controller/PolicyController.java
+++ b/backend/src/main/java/com/chalana/insurance/controller/PolicyController.java
@@ -1,0 +1,33 @@
+package com.chalana.insurance.controller;
+
+import com.chalana.insurance.dto.PolicyRequest;
+import com.chalana.insurance.dto.PolicyResponse;
+import com.chalana.insurance.service.PolicyService;
+import lombok.RequiredArgsConstructor;
+import org.springframework.security.access.prepost.PreAuthorize;
+import org.springframework.security.core.Authentication;
+import org.springframework.web.bind.annotation.*;
+
+import jakarta.validation.Valid;
+import java.util.List;
+
+@RestController
+@RequestMapping("/api/policies")
+@RequiredArgsConstructor
+public class PolicyController {
+
+    private final PolicyService policyService;
+
+    // Create a new policy (ADMIN, AGENT)
+    @PreAuthorize("hasAnyRole('ADMIN', 'AGENT')")
+    @PostMapping
+    public PolicyResponse createPolicy(@Valid @RequestBody PolicyRequest request, Authentication auth) {
+        return policyService.createPolicy(request, auth.getName());
+    }
+
+    // Public endpoint to get all policies
+    @GetMapping
+    public List<PolicyResponse> getAllPolicies() {
+        return policyService.getAllPolicies();
+    }
+}

--- a/backend/src/main/java/com/chalana/insurance/dto/PolicyRequest.java
+++ b/backend/src/main/java/com/chalana/insurance/dto/PolicyRequest.java
@@ -15,12 +15,18 @@ public class PolicyRequest {
     @NotBlank
     private String type;
 
+    @Positive
+    @Min(1)
     @NotNull
     private BigDecimal coverageAmount;
 
+    @Positive
+    @Min(1)
     @NotNull
     private BigDecimal premium;
 
+    @Positive
+    @Min(1)
     @NotNull
     private Integer durationMonths;
 

--- a/backend/src/main/java/com/chalana/insurance/dto/PolicyRequest.java
+++ b/backend/src/main/java/com/chalana/insurance/dto/PolicyRequest.java
@@ -1,0 +1,29 @@
+package com.chalana.insurance.dto;
+
+import jakarta.validation.constraints.*;
+import lombok.Getter;
+import lombok.Setter;
+
+import java.math.BigDecimal;
+
+@Getter
+@Setter
+public class PolicyRequest {
+    @NotBlank
+    private String name;
+
+    @NotBlank
+    private String type;
+
+    @NotNull
+    private BigDecimal coverageAmount;
+
+    @NotNull
+    private BigDecimal premium;
+
+    @NotNull
+    private Integer durationMonths;
+
+    private String description;
+}
+

--- a/backend/src/main/java/com/chalana/insurance/dto/PolicyResponse.java
+++ b/backend/src/main/java/com/chalana/insurance/dto/PolicyResponse.java
@@ -1,0 +1,22 @@
+package com.chalana.insurance.dto;
+
+import lombok.*;
+
+import java.math.BigDecimal;
+import java.time.LocalDateTime;
+
+@Getter
+@Setter
+@AllArgsConstructor
+@NoArgsConstructor
+public class PolicyResponse {
+    private Long id;
+    private String name;
+    private String type;
+    private BigDecimal coverageAmount;
+    private BigDecimal premium;
+    private Integer durationMonths;
+    private String description;
+    private String createdBy;
+    private LocalDateTime createdAt;
+}

--- a/backend/src/main/java/com/chalana/insurance/model/Policy.java
+++ b/backend/src/main/java/com/chalana/insurance/model/Policy.java
@@ -1,0 +1,34 @@
+package com.chalana.insurance.model;
+
+import jakarta.persistence.*;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
+import java.math.BigDecimal;
+import java.time.LocalDateTime;
+
+@Entity
+@Getter
+@Setter
+@NoArgsConstructor
+@AllArgsConstructor
+@Table(name = "policies")
+public class Policy {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    private String name;
+    private String type;
+    private BigDecimal coverageAmount;
+    private BigDecimal premium;
+    private Integer durationMonths;
+    private String description;
+
+    private String createdBy;
+
+    private LocalDateTime createdAt = LocalDateTime.now();
+
+}

--- a/backend/src/main/java/com/chalana/insurance/model/Policy.java
+++ b/backend/src/main/java/com/chalana/insurance/model/Policy.java
@@ -5,6 +5,8 @@ import lombok.AllArgsConstructor;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 import lombok.Setter;
+import org.hibernate.annotations.CreationTimestamp;
+
 import java.math.BigDecimal;
 import java.time.LocalDateTime;
 
@@ -29,6 +31,7 @@ public class Policy {
 
     private String createdBy;
 
-    private LocalDateTime createdAt = LocalDateTime.now();
+    @CreationTimestamp
+    private LocalDateTime createdAt;
 
 }

--- a/backend/src/main/java/com/chalana/insurance/repository/PolicyRepository.java
+++ b/backend/src/main/java/com/chalana/insurance/repository/PolicyRepository.java
@@ -1,0 +1,7 @@
+package com.chalana.insurance.repository;
+
+import com.chalana.insurance.model.Policy;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface PolicyRepository extends JpaRepository<Policy, Long> {
+}

--- a/backend/src/main/java/com/chalana/insurance/service/PolicyService.java
+++ b/backend/src/main/java/com/chalana/insurance/service/PolicyService.java
@@ -1,0 +1,48 @@
+package com.chalana.insurance.service;
+
+import com.chalana.insurance.dto.PolicyRequest;
+import com.chalana.insurance.dto.PolicyResponse;
+import com.chalana.insurance.model.Policy;
+import com.chalana.insurance.repository.PolicyRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+
+import java.util.List;
+import java.util.stream.Collectors;
+
+@Service
+@RequiredArgsConstructor
+public class PolicyService {
+
+    private final PolicyRepository policyRepository;
+
+    public PolicyResponse createPolicy(PolicyRequest request, String createdBy) {
+        Policy policy = new Policy();
+        policy.setName(request.getName());
+        policy.setType(request.getType());
+        policy.setCoverageAmount(request.getCoverageAmount());
+        policy.setPremium(request.getPremium());
+        policy.setDurationMonths(request.getDurationMonths());
+        policy.setDescription(request.getDescription());
+        policy.setCreatedBy(createdBy);
+
+        Policy saved = policyRepository.save(policy);
+
+        return mapToResponse(saved);
+    }
+
+    public List<PolicyResponse> getAllPolicies() {
+        return policyRepository.findAll().stream()
+                .map(this::mapToResponse)
+                .collect(Collectors.toList());
+    }
+
+    private PolicyResponse mapToResponse(Policy p) {
+        return new PolicyResponse(
+                p.getId(), p.getName(), p.getType(),
+                p.getCoverageAmount(), p.getPremium(),
+                p.getDurationMonths(), p.getDescription(),
+                p.getCreatedBy(), p.getCreatedAt()
+        );
+    }
+}

--- a/backend/src/main/java/com/chalana/insurance/service/PolicyService.java
+++ b/backend/src/main/java/com/chalana/insurance/service/PolicyService.java
@@ -4,6 +4,7 @@ import com.chalana.insurance.dto.PolicyRequest;
 import com.chalana.insurance.dto.PolicyResponse;
 import com.chalana.insurance.model.Policy;
 import com.chalana.insurance.repository.PolicyRepository;
+import jakarta.transaction.Transactional;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 
@@ -16,6 +17,7 @@ public class PolicyService {
 
     private final PolicyRepository policyRepository;
 
+    @Transactional
     public PolicyResponse createPolicy(PolicyRequest request, String createdBy) {
         Policy policy = new Policy();
         policy.setName(request.getName());


### PR DESCRIPTION
# ✅ Pull Request: Feature implemented Insurance policy management

**Summary:**
This pull request adds the core feature for managing insurance policies within the application. It introduces backend support for creating and retrieving insurance policies by authorized users.

---

## ✨ What's New

- `PolicyController`: Exposes endpoints to create a policy (`POST /api/policies`) and retrieve all policies (`GET /api/policies`).
- `PolicyService`: Handles business logic for saving and fetching policy data.
- `Policy`: Entity class representing the policy table in the database.
- `PolicyRepository`: Extends Spring Data JPA's `JpaRepository` to persist policies.
- DTOs:
  - `PolicyRequest`: For capturing request data on policy creation.
  - `PolicyResponse`: For sending response data to the client.

---

## 📌 Endpoints

- `POST /api/policies` — Create a new policy (Allowed for `ADMIN`, `AGENT`)
- `GET /api/policies` — Fetch all policies (Open to all)

---

## 🔐 Access Control

- Role-based access via `@PreAuthorize("hasAnyRole('ADMIN', 'AGENT')")` for policy creation.

---

## 🧩 Issues

Closes #5  — Insurance policy management feature
