### PR TITLE
Feature - Implement customer policy enrollment feature

### DIFF
--- a/backend/src/main/java/com/chalana/insurance/controller/PolicyController.java
+++ b/backend/src/main/java/com/chalana/insurance/controller/PolicyController.java
@@ -2,8 +2,10 @@ package com.chalana.insurance.controller;
 
 import com.chalana.insurance.dto.PolicyRequest;
 import com.chalana.insurance.dto.PolicyResponse;
+import com.chalana.insurance.service.CustomerPolicyService;
 import com.chalana.insurance.service.PolicyService;
 import lombok.RequiredArgsConstructor;
+import org.springframework.http.ResponseEntity;
 import org.springframework.security.access.prepost.PreAuthorize;
 import org.springframework.security.core.Authentication;
 import org.springframework.web.bind.annotation.*;
@@ -17,6 +19,7 @@ import java.util.List;
 public class PolicyController {
 
     private final PolicyService policyService;
+    private final CustomerPolicyService customerPolicyService;
 
     // Create a new policy (ADMIN, AGENT)
     @PreAuthorize("hasAnyRole('ADMIN', 'AGENT')")
@@ -30,4 +33,29 @@ public class PolicyController {
     public List<PolicyResponse> getAllPolicies() {
         return policyService.getAllPolicies();
     }
+
+    @PreAuthorize("hasRole('CUSTOMER')")
+    @PostMapping("/enroll/{id}")
+    public ResponseEntity<?> enrollPolicy(@PathVariable Long id, Authentication auth) {
+        customerPolicyService.enrollPolicy(auth.getName(), id);
+        return ResponseEntity.ok("Policy enrolled successfully");
+    }
+
+    @PreAuthorize("hasRole('CUSTOMER')")
+    @GetMapping("/my")
+    public List<PolicyResponse> myPolicies(Authentication auth) {
+        return customerPolicyService.getCustomerPolicies(auth.getName())
+                .stream()
+                .map(cp -> {
+                    var p = cp.getPolicy();
+                    return new PolicyResponse(
+                            p.getId(), p.getName(), p.getType(),
+                            p.getCoverageAmount(), p.getPremium(),
+                            p.getDurationMonths(), p.getDescription(),
+                            p.getCreatedBy(), p.getCreatedAt()
+                    );
+                })
+                .toList();
+    }
+
 }

--- a/backend/src/main/java/com/chalana/insurance/model/CustomerPolicy.java
+++ b/backend/src/main/java/com/chalana/insurance/model/CustomerPolicy.java
@@ -2,6 +2,7 @@ package com.chalana.insurance.model;
 
 import jakarta.persistence.*;
 import lombok.*;
+import org.hibernate.annotations.CreationTimestamp;
 
 import java.time.LocalDateTime;
 
@@ -26,6 +27,4 @@ public class CustomerPolicy {
     @ManyToOne
     @JoinColumn(name = "policy_id")
     private Policy policy;
-
-    private LocalDateTime enrolledAt = LocalDateTime.now();
 }

--- a/backend/src/main/java/com/chalana/insurance/model/CustomerPolicy.java
+++ b/backend/src/main/java/com/chalana/insurance/model/CustomerPolicy.java
@@ -1,0 +1,31 @@
+package com.chalana.insurance.model;
+
+import jakarta.persistence.*;
+import lombok.*;
+
+import java.time.LocalDateTime;
+
+@Entity
+@Getter
+@Setter
+@NoArgsConstructor
+@AllArgsConstructor
+@Table(name = "customer_policies")
+public class CustomerPolicy {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    // Link to customer
+    @ManyToOne
+    @JoinColumn(name = "user_id")
+    private User customer;
+
+    // Link to policy
+    @ManyToOne
+    @JoinColumn(name = "policy_id")
+    private Policy policy;
+
+    private LocalDateTime enrolledAt = LocalDateTime.now();
+}

--- a/backend/src/main/java/com/chalana/insurance/repository/CustomerPolicyRepository.java
+++ b/backend/src/main/java/com/chalana/insurance/repository/CustomerPolicyRepository.java
@@ -1,6 +1,7 @@
 package com.chalana.insurance.repository;
 
 import com.chalana.insurance.model.CustomerPolicy;
+import com.chalana.insurance.model.Policy;
 import com.chalana.insurance.model.User;
 import org.springframework.data.jpa.repository.JpaRepository;
 
@@ -8,4 +9,6 @@ import java.util.List;
 
 public interface CustomerPolicyRepository extends JpaRepository<CustomerPolicy, Long> {
     List<CustomerPolicy> findByCustomer(User user);
+
+    boolean existsByCustomerAndPolicy(User customer, Policy policy);
 }

--- a/backend/src/main/java/com/chalana/insurance/repository/CustomerPolicyRepository.java
+++ b/backend/src/main/java/com/chalana/insurance/repository/CustomerPolicyRepository.java
@@ -1,0 +1,11 @@
+package com.chalana.insurance.repository;
+
+import com.chalana.insurance.model.CustomerPolicy;
+import com.chalana.insurance.model.User;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+import java.util.List;
+
+public interface CustomerPolicyRepository extends JpaRepository<CustomerPolicy, Long> {
+    List<CustomerPolicy> findByCustomer(User user);
+}

--- a/backend/src/main/java/com/chalana/insurance/service/CustomerPolicyService.java
+++ b/backend/src/main/java/com/chalana/insurance/service/CustomerPolicyService.java
@@ -1,0 +1,45 @@
+package com.chalana.insurance.service;
+
+
+import com.chalana.insurance.model.CustomerPolicy;
+import com.chalana.insurance.model.Policy;
+import com.chalana.insurance.model.User;
+import com.chalana.insurance.repository.CustomerPolicyRepository;
+import com.chalana.insurance.repository.PolicyRepository;
+import com.chalana.insurance.repository.UserRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+
+import java.util.List;
+
+@Service
+@RequiredArgsConstructor
+public class CustomerPolicyService {
+
+    private final CustomerPolicyRepository customerPolicyRepository;
+    private final PolicyRepository policyRepository;
+    private final UserRepository userRepository;
+
+
+    public void enrollPolicy(String username, Long policyID) {
+
+        User customer = userRepository.findByUsername(username)
+                .orElseThrow(() -> new RuntimeException("User not found"));
+
+        Policy policy = policyRepository.findById(policyID)
+                .orElseThrow(() -> new RuntimeException("Policy not found"));
+
+        CustomerPolicy cp = new CustomerPolicy();
+        cp.setCustomer(customer);
+        cp.setPolicy(policy);
+
+        customerPolicyRepository.save(cp);
+    }
+
+    public List<CustomerPolicy> getCustomerPolicies(String username) {
+        User customer = userRepository.findByUsername(username)
+                .orElseThrow(() -> new RuntimeException("User not found"));
+
+        return customerPolicyRepository.findByCustomer(customer);
+    }
+}

--- a/backend/src/main/java/com/chalana/insurance/service/CustomerPolicyService.java
+++ b/backend/src/main/java/com/chalana/insurance/service/CustomerPolicyService.java
@@ -29,6 +29,11 @@ public class CustomerPolicyService {
         Policy policy = policyRepository.findById(policyID)
                 .orElseThrow(() -> new RuntimeException("Policy not found"));
 
+        // Check if the customer is already enrolled in the policy
+        if (customerPolicyRepository.existsByCustomerAndPolicy(customer, policy)) {
+            throw new RuntimeException("Customer is already enrolled in this policy");
+        }
+
         CustomerPolicy cp = new CustomerPolicy();
         cp.setCustomer(customer);
         cp.setPolicy(policy);


### PR DESCRIPTION
This PR extends the insurance management system to support customer policy enrollment and retrieval.

---

### ✨ What's Implemented

- 🔐 **Policy Enrollment Endpoint** (`POST /api/policies/enroll/{id}`):
  - Allows authenticated customers to enroll in a selected policy.

- 📄 **My Policies Endpoint** (`GET /api/policies/my`):
  - Retrieves all policies enrolled by the currently authenticated customer.

- 🧱 **CustomerPolicy Entity**:
  - New entity to manage the many-to-many relationship between customers and policies with enrollment timestamp.

- 💾 **CustomerPolicyRepository**:
  - Repository interface to access customer policy data.

- ⚙️ **CustomerPolicyService**:
  - Handles logic for enrolling in and retrieving customer policies.

---

### 🔐 Access Control

- Both endpoints restricted to users with the `CUSTOMER` role using `@PreAuthorize`.

---

### 📌 Issue

Closes #7 
